### PR TITLE
Fix errors when opening the project in Android Studio 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - tools
     
      # The BuildTools version used by your project
-    - build-tools-26.0.2
+    - build-tools-28.0.3
     
     - platform-tools
     
@@ -18,7 +18,7 @@ android:
     - extra-google-m2repository
     
     # The SDK version used to compile your project
-    - android-26
+    - android-28
 
   licenses:
     - '.+'

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 # Gradle Dependency
 **Requirements**
 * Latest version of Android Studio</li>
-* Android-SDK Build tools v27</li>
-* API 26 SDK Platform</li>
+* Android-SDK Build tools v28</li>
+* API 28 SDK Platform</li>
 * Latest version of Android Support Library</li>
 * Java SE Development Kit 8</li>
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -31,11 +31,10 @@ allprojects {
 
     //NOTE: This is important
     rootProject.ext {
-        BuildTools = "26.0.2"
         MinSdk = 15
         TargetSdk = 26
-        CompileSdk = 26
-        SupportLibrary = "26.0.2"
+        CompileSdk = 28
+        SupportLibrary = "28.0.0"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.jakewharton.butterknife'
 apply plugin: 'com.github.dcendents.android-maven'
 
@@ -33,13 +32,11 @@ buildscript {
 
     dependencies {
         classpath 'com.jakewharton:butterknife-gradle-plugin:9.0.0-SNAPSHOT'
-        classpath 'me.tatarka:gradle-retrolambda:3.7.0'
     }
 }
 
 android {
     compileSdkVersion rootProject.ext.CompileSdk
-    buildToolsVersion rootProject.ext.BuildTools
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
@@ -74,46 +71,44 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
 
-    retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.5.1'
-    compile 'com.github.danimahardhika.candybar-library:PreLollipopTransitions:3.1.2'
+    implementation 'com.github.danimahardhika.candybar-library:PreLollipopTransitions:3.1.2'
 
-    compile "com.android.support:appcompat-v7:$rootProject.ext.SupportLibrary"
-    compile "com.android.support:recyclerview-v7:$rootProject.ext.SupportLibrary"
-    compile "com.android.support:cardview-v7:$rootProject.ext.SupportLibrary"
-    compile "com.android.support:design:$rootProject.ext.SupportLibrary"
-    compile "com.android.support:palette-v7:$rootProject.ext.SupportLibrary"
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.SupportLibrary"
+    implementation "com.android.support:recyclerview-v7:$rootProject.ext.SupportLibrary"
+    implementation "com.android.support:cardview-v7:$rootProject.ext.SupportLibrary"
+    implementation "com.android.support:design:$rootProject.ext.SupportLibrary"
+    implementation "com.android.support:palette-v7:$rootProject.ext.SupportLibrary"
 
-    compile 'com.bluelinelabs:logansquare:1.3.7'
+    implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
-    compile 'com.jakewharton:butterknife:9.0.0-SNAPSHOT'
+    implementation 'com.jakewharton:butterknife:9.0.0-SNAPSHOT'
     annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-SNAPSHOT'
 
-    compile 'com.squareup.okhttp3:okhttp:3.9.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.9.1'
 
-    compile group: 'cz.msebera.android', name: 'httpclient', version: '4.4.1.1'
-    compile 'uk.co.chrisjenx:calligraphy:2.3.0'
-    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
-    compile 'com.afollestad.material-dialogs:core:0.9.5.0'
-    compile 'com.mikhaellopez:circularimageview:3.0.2'
-    compile 'com.anjlab.android.iab.v3:library:1.0.44'
-    compile 'com.github.chrisbanes:PhotoView:2.1.3'
-    compile 'com.google.android.apps.muzei:muzei-api:2.0'
-    compile 'org.sufficientlysecure:html-textview:3.5'
-    compile 'com.github.KeepSafe:TapTargetView:1.9.1'
-    compile 'com.sothree.slidinguppanel:library:3.3.1'
-    compile 'me.zhanghai.android.materialprogressbar:library:1.4.2'
+    implementation group: 'cz.msebera.android', name: 'httpclient', version: '4.4.1.1'
+    implementation 'uk.co.chrisjenx:calligraphy:2.3.0'
+    implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
+    implementation 'com.afollestad.material-dialogs:core:0.9.5.0'
+    implementation 'com.mikhaellopez:circularimageview:3.0.2'
+    implementation 'com.anjlab.android.iab.v3:library:1.0.44'
+    implementation 'com.github.chrisbanes:PhotoView:2.1.3'
+    implementation 'com.google.android.apps.muzei:muzei-api:2.0'
+    implementation 'org.sufficientlysecure:html-textview:3.5'
+    implementation 'com.github.KeepSafe:TapTargetView:1.9.1'
+    implementation 'com.sothree.slidinguppanel:library:3.3.1'
+    implementation 'me.zhanghai.android.materialprogressbar:library:1.4.2'
 
-    compile 'com.github.danimahardhika:cafebar:1.3.2'
+    implementation 'com.github.danimahardhika:cafebar:1.3.2'
     implementation('com.github.danimahardhika.android-helpers:core:-SNAPSHOT') {
         changing = true
     }
-    compile 'com.github.danimahardhika.android-helpers:animation:0.1.0'
-    compile 'com.github.danimahardhika.android-helpers:license:0.1.0'
-    compile 'com.github.danimahardhika.android-helpers:permission:0.1.0'
+    implementation 'com.github.danimahardhika.android-helpers:animation:0.1.0'
+    implementation 'com.github.danimahardhika.android-helpers:license:0.1.0'
+    implementation 'com.github.danimahardhika.android-helpers:permission:0.1.0'
 }
 
 configurations.all {

--- a/library/library.iml
+++ b/library/library.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":library" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":library" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -24,23 +24,21 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
-    <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+    <output url="file://$MODULE_DIR$/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/javac/debugUnitTest/compileDebugUnitTestJavaWithJavac/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r2/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debug/compileDebugAidl/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debugAndroidTest/compileDebugAndroidTestAidl/out" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debugAndroidTest/compileDebugAndroidTestRenderscript/out" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
@@ -86,65 +84,102 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/attr" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/generated/not_namespaced_r_class_sources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/generated/source/r" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/aapt_friendly_merged_manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotation_processor_list" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations_typedef_file" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations_zip" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check_manifest_result" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/compile_only_not_namespaced_r_class_jar" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/consumer_proguard_file" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/intermediate-jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaPrecompile" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javac" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/library_and_local_jars_jni" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/library_assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/library_manifest" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint_jar" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/merged_manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/packaged-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/packaged_res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/public_res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shader_assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 26 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 28 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="com.github.KeepSafe:TapTargetView-1.9.1" level="project" />
-    <orderEntry type="library" name="org.sufficientlysecure:html-textview-3.5" level="project" />
-    <orderEntry type="library" name="com.android.support:recyclerview-v7-26.0.2" level="project" />
-    <orderEntry type="library" name="com.android.support:support-media-compat-26.0.2" level="project" />
-    <orderEntry type="library" name="com.android.support:support-vector-drawable-26.0.2" level="project" />
-    <orderEntry type="library" name="com.android.support:palette-v7-26.0.2" level="project" />
-    <orderEntry type="library" name="com.github.danimahardhika.android-helpers:animation-0.1.0" level="project" />
-    <orderEntry type="library" name="com.github.danimahardhika:cafebar-1.3.2" level="project" />
-    <orderEntry type="library" name="com.github.danimahardhika.candybar-library:PreLollipopTransitions-3.1.2" level="project" />
-    <orderEntry type="library" name="com.android.support:support-fragment-26.0.2" level="project" />
-    <orderEntry type="library" name="com.github.danimahardhika.android-helpers:permission-0.1.0" level="project" />
-    <orderEntry type="library" name="cz.msebera.android:httpclient:4.4.1.1@jar" level="project" />
-    <orderEntry type="library" name="com.jakewharton:butterknife-annotations:9.0.0-SNAPSHOT@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:appcompat-v7-26.0.2" level="project" />
-    <orderEntry type="library" name="com.mikhaellopez:circularimageview-3.0.2" level="project" />
-    <orderEntry type="library" name="com.android.support:support-core-utils-26.0.2" level="project" />
-    <orderEntry type="library" name="com.jakewharton:butterknife-9.0.0-SNAPSHOT" level="project" />
-    <orderEntry type="library" name="com.android.support:support-core-ui-26.0.2" level="project" />
-    <orderEntry type="library" name="me.zhanghai.android.materialprogressbar:library-1.4.2" level="project" />
-    <orderEntry type="library" name="com.github.danimahardhika.android-helpers:core-0.1.0" level="project" />
-    <orderEntry type="library" name="com.afollestad.material-dialogs:core-0.9.5.0" level="project" />
-    <orderEntry type="library" name="com.squareup.okio:okio:1.13.0@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:support-compat-26.0.2" level="project" />
-    <orderEntry type="library" name="com.nostra13.universalimageloader:universal-image-loader:1.9.5@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:support-annotations:26.0.2@jar" level="project" />
-    <orderEntry type="library" name="com.sothree.slidinguppanel:library-3.3.1" level="project" />
-    <orderEntry type="library" name="com.android.support:support-v4-26.0.2" level="project" />
-    <orderEntry type="library" name="com.anjlab.android.iab.v3:library:1.0.44@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:animated-vector-drawable-26.0.2" level="project" />
-    <orderEntry type="library" name="com.android.support:transition-26.0.2" level="project" />
-    <orderEntry type="library" name="com.github.chrisbanes:PhotoView-1.3.1" level="project" />
-    <orderEntry type="library" name="com.google.android.apps.muzei:muzei-api:2.0@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:design-26.0.2" level="project" />
-    <orderEntry type="library" name="com.squareup.okhttp3:okhttp:3.9.0@jar" level="project" />
-    <orderEntry type="library" name="com.fasterxml.jackson.core:jackson-core:2.5.1@jar" level="project" />
-    <orderEntry type="library" name="com.android.support:cardview-v7-26.0.2" level="project" />
-    <orderEntry type="library" name="uk.co.chrisjenx:calligraphy-2.3.0" level="project" />
-    <orderEntry type="library" name="com.github.danimahardhika.android-helpers:license-0.1.0" level="project" />
-    <orderEntry type="library" name="com.bluelinelabs:logansquare:1.3.7@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:design:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.danimahardhika.candybar-library:PreLollipopTransitions:3.1.2@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-fragment:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:localbroadcastmanager:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:viewmodel:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.fasterxml.jackson.core:jackson-core:2.5.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:loader:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:runtime:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata-core:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:cursoradapter:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: uk.co.chrisjenx:calligraphy:2.3.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-compat:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:cardview-v7:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.KeepSafe:TapTargetView:1.9.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.danimahardhika.android-helpers:permission:0.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:palette-v7:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.danimahardhika.android-helpers:animation:0.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.jakewharton:butterknife-runtime:9.0.0-SNAPSHOT@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.anjlab.android.iab.v3:library:1.0.44@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:recyclerview-v7:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:28.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:interpolator:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:transition:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata:1.1.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:drawerlayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-v4:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.jakewharton:butterknife-annotations:9.0.0-SNAPSHOT@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:documentfile:28.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.mockito:mockito-core:1.10.19@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:slidingpanelayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: org.sufficientlysecure:html-textview:3.5@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.13.0@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.objenesis:objenesis:2.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: cz.msebera.android:httpclient:4.4.1.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:collections:28.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.chrisbanes:PhotoView:2.1.3@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:asynclayoutinflater:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:print:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: me.zhanghai.android.materialprogressbar:library:1.4.2@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.nostra13.universalimageloader:universal-image-loader:1.9.5@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.jakewharton:butterknife:9.0.0-SNAPSHOT@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.9.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.sothree.slidinguppanel:library:3.3.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.danimahardhika:cafebar:1.3.2@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:common:1.1.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:versionedparcelable:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.afollestad.material-dialogs:core:0.9.5.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.danimahardhika.android-helpers:license:0.1.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:viewpager:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.apps.muzei:muzei-api:2.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:common:1.1.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.danimahardhika.android-helpers:core:-SNAPSHOT@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:coordinatorlayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:customview:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.bluelinelabs:logansquare:1.3.7@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:swiperefreshlayout:28.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.mikhaellopez:circularimageview:3.0.2@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-media-compat:28.0.0@aar" level="project" />
   </component>
 </module>


### PR DESCRIPTION
- Update Android Gradle Plugin to 3.3.0
- Update Gradle to 4.10.1
- Change "compile" instances in build.gradle to "implementation"
- Remove no longer needed BuildTools variable (build tool version is automatically determined by the Android Gradle Plugin version)
- Remove Retrolambda (Java 8 features like lambda methods are fully supported already: https://developer.android.com/studio/write/java8-support)
- Update CompileSdk to 28, Support Library version to 28.0.0

Fixes #144